### PR TITLE
declare tools on datachannel open event

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -4,6 +4,8 @@ import { Link } from "react-router";
 import logo from "/assets/thumb-down.svg";
 import Screen from "./Screen";
 import { Debug } from "./debug/Debug";
+import { getProfile } from "../profile";
+import { declareTools } from "./whiteboard/declareTools";
 
 export default function App() {
   const [isSessionActive, setIsSessionActive] = useState(false);
@@ -253,6 +255,9 @@ export default function App() {
 
       // Set session active when the data channel is opened
       dataChannel.addEventListener("open", () => {
+        // start by declaring tools
+        const profile = getProfile();
+        sendClientEvent(declareTools(profile));
         setIsSessionActive(true);
         setEvents([]);
       });

--- a/client/components/whiteboard/useWhiteboardState.js
+++ b/client/components/whiteboard/useWhiteboardState.js
@@ -1,27 +1,11 @@
 import { useState, useEffect } from "react";
 import { WELCOME_HTML } from "./constants";
-import { declareTools } from "./declareTools";
 import { processToolCalls } from "./processToolCalls";
-import { getProfile } from "../../profile";
 
 export function useWhiteboardState(isSessionActive, sendClientEvent, events) {
-  const [toolsAdded, setToolsAdded] = useState(false);
   const [whiteboardHtml, setWhiteboardHtml] = useState(WELCOME_HTML);
   const [isResponseComplete, setIsResponseComplete] = useState(true);
   const [lastResponseId, setLastResponseId] = useState(null);
-
-  // Initialize tools when session becomes active
-  useEffect(() => {
-    if (!events || events.length === 0 || toolsAdded) return;
-    // Find the most recent session.created event
-    const sessionCreatedEvent = events.find(
-      (event) => event.type === "session.created",
-    );
-    const profile = getProfile();
-    if (!sessionCreatedEvent) return;
-    sendClientEvent(declareTools(profile));
-    setToolsAdded(true);
-  }, [events, toolsAdded, sendClientEvent]);
 
   // Process function calls and events
   useEffect(() => {
@@ -36,13 +20,6 @@ export function useWhiteboardState(isSessionActive, sendClientEvent, events) {
       sendClientEvent,
     );
   }, [events, lastResponseId, whiteboardHtml, sendClientEvent]);
-
-  // Reset state when session becomes inactive
-  useEffect(() => {
-    if (!isSessionActive) {
-      setToolsAdded(false);
-    }
-  }, [isSessionActive]);
 
   return {
     whiteboardHtml,


### PR DESCRIPTION
First improvement on verbosity
The tools are declared as firstevent when opening the data channel.
Before, the first event was the user voice.
It now follow more closely the content of the white board.